### PR TITLE
Performance Counters

### DIFF
--- a/Data/Json/DebuggerJdi.json
+++ b/Data/Json/DebuggerJdi.json
@@ -73,6 +73,19 @@
       "args": 1,
       "help": "Check whenever command exists",
       "output": "Bool"
+    },
+
+    "GetPerformanceCounter": {
+      "internal": true,
+      "args": 1,
+      "help": "Get the value of the performance counter",
+      "output": "UInt64"
+    },
+
+    "ResetPerformanceCounter": {
+      "internal": true,
+      "args": 1,
+      "help": "Reset the value of the performance counter"
     }
 
   }

--- a/Data/Json/HLEJdi.json
+++ b/Data/Json/HLEJdi.json
@@ -106,12 +106,20 @@
       "output": "Array: [String] / [empty string] (not found)"
     },
 
+    "OSDateTime": {
+      "internal": true,
+      "help": "Convert Gekko ticks to human-readable time (including date)",
+      "usage": [
+        "Syntax: OSDateTime"
+      ],
+      "output": "Array: [String]"
+    },
+
     "OSTime": {
       "internal": true,
-      "help": "Convert Geeko ticks to human-readable time",
-      "args": 1,
+      "help": "Convert Gekko ticks to human-readable time (no date)",
       "usage": [
-        "Syntax: OSTime <GekkoTbrValue>"
+        "Syntax: OSTime"
       ],
       "output": "Array: [String]"
     },

--- a/SRC/DSP/DspCore.cpp
+++ b/SRC/DSP/DspCore.cpp
@@ -464,6 +464,16 @@ namespace DSP
 		return found;
 	}
 
+	int64_t DspCore::GetInstructionCounter()
+	{
+		return instructionCounter;
+	}
+
+	void DspCore::ResetInstructionCounter()
+	{
+		instructionCounter = 0;
+	}
+
 	// Execute single instruction (by interpreter)
 	void DspCore::Step()
 	{

--- a/SRC/DSP/DspCore.h
+++ b/SRC/DSP/DspCore.h
@@ -188,6 +188,8 @@ namespace DSP
 
 		int repeatCount = 0;		// Internal register for the `rep` instruction.
 
+		int64_t instructionCounter = 0;
+
 	public:
 
 		static const size_t MaxInstructionSizeInBytes = 4;		// max instruction size
@@ -224,6 +226,8 @@ namespace DSP
 		void RemoveAllWatches();
 		void ListWatches(std::list<DspAddress>& watches);
 		bool TestWatch(DspAddress dmemAddress);
+		int64_t GetInstructionCounter();
+		void ResetInstructionCounter();
 
 		// Register access
 

--- a/SRC/DSP/DspInterpreter.cpp
+++ b/SRC/DSP/DspInterpreter.cpp
@@ -187,6 +187,8 @@ namespace DSP
 				case DspRegularInstruction::btstl: btstl(info); break;
 				case DspRegularInstruction::btsth: btsth(info); break;
 			}
+
+			core->instructionCounter++;
 		}
 		else
 		{
@@ -237,6 +239,8 @@ namespace DSP
 				case DspParallelMemInstruction::nop:
 					break;
 			}
+
+			core->instructionCounter += 2;
 		}
 
 		// If there were no control transfers, increase pc by the instruction size

--- a/SRC/Debugger/DebugCommands.cpp
+++ b/SRC/Debugger/DebugCommands.cpp
@@ -261,6 +261,24 @@ namespace Debug
         return output;
     }
 
+    // Get the value of the debug counter
+    static Json::Value* CmdGetPerformanceCounter(std::vector<std::string>& args)
+    {
+        PerfCounter counter = (PerfCounter)strtoul(args[1].c_str(), nullptr, 0);
+        Json::Value* output = new Json::Value();
+        output->type = Json::ValueType::Int;
+        output->value.AsInt = g_PerfCounters->GetCounter(counter);
+        return output;
+    }
+
+    // Reset the value of the debug counter
+    static Json::Value* CmdResetPerformanceCounter(std::vector<std::string>& args)
+    {
+        PerfCounter counter = (PerfCounter)strtoul(args[1].c_str(), nullptr, 0);
+        g_PerfCounters->ResetCounter(counter);
+        return nullptr;
+    }
+
     void Reflector()
     {
         JDI::Hub.AddCmd("script", cmd_script);
@@ -271,5 +289,7 @@ namespace Debug
         JDI::Hub.AddCmd("qd", QueryDebugMessages);
         JDI::Hub.AddCmd("help", ShowHelp);
         JDI::Hub.AddCmd("IsCommandExists", IsCommandExists);
+        JDI::Hub.AddCmd("GetPerformanceCounter", CmdGetPerformanceCounter);
+        JDI::Hub.AddCmd("ResetPerformanceCounter", CmdResetPerformanceCounter);
     }
 }

--- a/SRC/Debugger/Debugger.h
+++ b/SRC/Debugger/Debugger.h
@@ -6,3 +6,4 @@
 #include "DebugCommands.h"
 #include "EventLog.h"
 #include "SamplingProfiler.h"
+#include "Perf.h"

--- a/SRC/Debugger/Perf.cpp
+++ b/SRC/Debugger/Perf.cpp
@@ -1,0 +1,66 @@
+
+#include "pch.h"
+
+namespace Debug
+{
+	PerfCounters* g_PerfCounters = nullptr;
+
+	PerfCounters::PerfCounters()
+	{
+	}
+
+	PerfCounters::~PerfCounters()
+	{
+	}
+
+	int64_t PerfCounters::GetCounter(PerfCounter counter)
+	{
+		int64_t value = 0;
+
+		switch (counter)
+		{
+			case PerfCounter::GekkoInstructions:
+				return Gekko::Gekko->GetInstructionCounter();
+				break;
+			case PerfCounter::DspInstructions:
+				return Flipper::DSP->core->GetInstructionCounter();
+				break;
+			case PerfCounter::VIs:
+				return pi.intCounters[(size_t)PIInterruptSource::VI];
+				break;
+			case PerfCounter::PEs:
+				return pi.intCounters[(size_t)PIInterruptSource::PE_FINISH];
+				break;
+		}
+
+		return value;
+	}
+
+	void PerfCounters::ResetCounter(PerfCounter counter)
+	{
+		switch (counter)
+		{
+			case PerfCounter::GekkoInstructions:
+				Gekko::Gekko->ResetInstructionCounter();
+				break;
+			case PerfCounter::DspInstructions:
+				Flipper::DSP->core->ResetInstructionCounter();
+				break;
+			case PerfCounter::VIs:
+				pi.intCounters[(size_t)PIInterruptSource::VI] = 0;
+				break;
+			case PerfCounter::PEs:
+				pi.intCounters[(size_t)PIInterruptSource::PE_FINISH] = 0;
+				break;
+		}
+	}
+
+	void PerfCounters::ResetAllCounters()
+	{
+		for (int i = 0; i < (int)PerfCounter::Max; i++)
+		{
+			ResetCounter((PerfCounter)i);
+		}
+	}
+
+}

--- a/SRC/Debugger/Perf.h
+++ b/SRC/Debugger/Perf.h
@@ -1,0 +1,30 @@
+// Performance Counters
+
+#pragma once
+
+namespace Debug
+{
+
+	enum class PerfCounter
+	{
+		GekkoInstructions = 0,
+		DspInstructions,
+		VIs,
+		PEs,
+
+		Max,
+	};
+
+	class PerfCounters
+	{
+	public:
+		PerfCounters();
+		~PerfCounters();
+
+		int64_t GetCounter(PerfCounter counter);
+		void ResetCounter(PerfCounter counter);
+		void ResetAllCounters();
+	};
+
+	extern PerfCounters* g_PerfCounters;
+}

--- a/SRC/Debugger/Readme.md
+++ b/SRC/Debugger/Readme.md
@@ -5,6 +5,7 @@ This component deals with the usual debugging tasks that all developers want to 
 - Collecting debug messages
 - Tracing
 - Code profiling
+- Performance counters
 
 This component no longer has anything to do with the debug console. The debug console code has been moved to the category of user interfaces and moved to the UI\\Legacy folder.
 

--- a/SRC/Debugger/Scripts/CMakeLists.txt
+++ b/SRC/Debugger/Scripts/CMakeLists.txt
@@ -3,4 +3,5 @@ add_library (Debugger SHARED
 	../EventLog.cpp
 	../Report.cpp
 	../SamplingProfiler.cpp
+	../Perf.cpp
 )

--- a/SRC/Debugger/Scripts/VS2015/Debugger.vcxproj
+++ b/SRC/Debugger/Scripts/VS2015/Debugger.vcxproj
@@ -27,6 +27,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="..\..\Perf.cpp" />
     <ClCompile Include="..\..\Report.cpp" />
     <ClCompile Include="..\..\SamplingProfiler.cpp" />
   </ItemGroup>
@@ -35,6 +36,7 @@
     <ClInclude Include="..\..\Debugger.h" />
     <ClInclude Include="..\..\EventLog.h" />
     <ClInclude Include="..\..\pch.h" />
+    <ClInclude Include="..\..\Perf.h" />
     <ClInclude Include="..\..\Report.h" />
     <ClInclude Include="..\..\SamplingProfiler.h" />
   </ItemGroup>

--- a/SRC/Debugger/Scripts/VS2015/Debugger.vcxproj.filters
+++ b/SRC/Debugger/Scripts/VS2015/Debugger.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="..\..\DebugCommands.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Perf.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\pch.h">
@@ -48,6 +51,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Report.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Perf.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/SRC/Debugger/Scripts/VS2019/Debugger.vcxproj
+++ b/SRC/Debugger/Scripts/VS2019/Debugger.vcxproj
@@ -27,6 +27,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="..\..\Perf.cpp" />
     <ClCompile Include="..\..\Report.cpp" />
     <ClCompile Include="..\..\SamplingProfiler.cpp" />
   </ItemGroup>
@@ -35,6 +36,7 @@
     <ClInclude Include="..\..\Debugger.h" />
     <ClInclude Include="..\..\EventLog.h" />
     <ClInclude Include="..\..\pch.h" />
+    <ClInclude Include="..\..\Perf.h" />
     <ClInclude Include="..\..\Report.h" />
     <ClInclude Include="..\..\SamplingProfiler.h" />
   </ItemGroup>

--- a/SRC/Debugger/Scripts/VS2019/Debugger.vcxproj.filters
+++ b/SRC/Debugger/Scripts/VS2019/Debugger.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="..\..\DebugCommands.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Perf.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\pch.h">
@@ -48,6 +51,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Report.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Perf.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/SRC/Debugger/pch.h
+++ b/SRC/Debugger/pch.h
@@ -21,5 +21,12 @@
 #include "../Common/String.h"
 
 #include "../GekkoCore/Gekko.h"
+#include "../HighLevel/HighLevel.h"
+#include "../Hardware/HWConfig.h"
+#include "../DSP/DSP.h"
+#include "../GX/GXCore.h"
+#include "../DVD/DVD.h"
+#include "../Hardware/HW.h"
+#include "../Hardware/PI.h"
 
 #include "Debugger.h"

--- a/SRC/DolwinEmu/Emulator.cpp
+++ b/SRC/DolwinEmu/Emulator.cpp
@@ -75,6 +75,8 @@ void EMUOpen(const std::wstring& filename)
     LoadFile(filename);   // Gekko PC will be set here
     HLEOpen();
 
+    Debug::g_PerfCounters->ResetAllCounters();
+
     emu.loaded = true;
     emu.lastLoaded = filename;
 }
@@ -128,6 +130,7 @@ void EMUCtor()
     JDI::Hub.AddNode(EMU_JDI_JSON, EmuReflector);
     DVD::InitSubsystem();
     HLEInit();
+    Debug::g_PerfCounters = new Debug::PerfCounters();
     emu.init = true;
 }
 
@@ -147,6 +150,7 @@ void EMUDtor()
     Flipper::Gx = nullptr;
     HLEShutdown();
     JDI::Hub.RemoveNode(DEBUGGER_JDI_JSON);
+    delete Debug::g_PerfCounters;
     emu.init = false;
 }
 

--- a/SRC/DolwinEmu/Emulator.h
+++ b/SRC/DolwinEmu/Emulator.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#define EMU_VERSION L"0.15"
+#define EMU_VERSION L"0.16"
 
 void    EMUGetHwConfig(HWConfig* config);
 

--- a/SRC/GekkoCore/Gekko.h
+++ b/SRC/GekkoCore/Gekko.h
@@ -175,9 +175,6 @@ namespace Gekko
         void ClearInterrupt();
         void Exception(Gekko::Exception code);
 
-        size_t GetOpcodeCount() { return ops; }
-        void ResetOpcodeCount() { ops = 0; }
-
         void ExecuteOpcodeDebug(uint32_t pc, uint32_t instr);
 
 #pragma region "Memory interface"
@@ -203,7 +200,7 @@ namespace Gekko
 
 #pragma endregion "Memory interface"
 
-#pragma region "Breakpoints"
+#pragma region "Debug"
 
         void AddBreakpoint(uint32_t addr);
         void RemoveBreakpoint(uint32_t addr);
@@ -216,7 +213,10 @@ namespace Gekko
         void ToggleBreakpoint(uint32_t addr);
         bool IsBreakpoint(uint32_t addr);
 
-#pragma endregion "Breakpoints"
+        int64_t GetInstructionCounter() { return ops; }
+        void ResetInstructionCounter() { ops = 0; }
+
+#pragma endregion "Debug"
 
     };
 

--- a/SRC/Hardware/CP_PE.cpp
+++ b/SRC/Hardware/CP_PE.cpp
@@ -6,13 +6,12 @@ using namespace Debug;
 
 // TODO: Refactoring hacks
 
-size_t done_num;   // number of drawdone (PE_FINISH) events
+size_t pe_done_num;   // number of drawdone (PE_FINISH) events
 
 static void CPDrawDoneCallback()
 {
-    done_num++;
-    vi.frames++;
-    if (done_num == 1)
+    pe_done_num++;
+    if (pe_done_num == 1)
     {
         vi.xfb = 0;     // disable VI output
     }
@@ -22,7 +21,6 @@ static void CPDrawDoneCallback()
 
 static void CPDrawTokenCallback(uint16_t tokenValue)
 {
-    vi.frames++;
     vi.xfb = 0;     // disable VI output
 
     Flipper::Gx->CPDrawTokenCallback(tokenValue);

--- a/SRC/Hardware/HW.cpp
+++ b/SRC/Hardware/HW.cpp
@@ -100,6 +100,7 @@ namespace Flipper
         VIClose();      // close GDI (if opened)
         DIClose();      // release streaming buffer
         MIClose();
+        PIClose();
 
         PADClose();
         GXClose();

--- a/SRC/Hardware/PI.cpp
+++ b/SRC/Hardware/PI.cpp
@@ -60,6 +60,13 @@ void PIAssertInt(uint32_t mask)
         }
     }
 
+#ifdef _LINUX
+    PIInterruptSource intSource = (PIInterruptSource)(31 - __builtin_clz(mask));
+#else
+    PIInterruptSource intSource = (PIInterruptSource)(31 - __lzcnt(mask));
+#endif
+    pi.intCounters[(size_t)intSource]++;
+
     if (pi.intsr & pi.intmr)
     {
         Gekko::Gekko->AssertInterrupt();
@@ -228,4 +235,14 @@ void PIOpen(HWConfig* config)
     MISetTrap(32, PI_BASE , PI_CPRegRead, PI_CPRegWrite);
     MISetTrap(32, PI_TOP  , PI_CPRegRead, PI_CPRegWrite);
     MISetTrap(32, PI_WRPTR, PI_CPRegRead, PI_CPRegWrite);
+
+    // Reset interrupt counters
+    for (size_t i = 0; i < (size_t)PIInterruptSource::Max; i++)
+    {
+        pi.intCounters[i] = 0;
+    }
+}
+
+void PIClose()
+{
 }

--- a/SRC/Hardware/PI.h
+++ b/SRC/Hardware/PI.h
@@ -67,6 +67,26 @@
 #define PI_CONFIG_MEMRSTB 0x00000002
 #define PI_CONFIG_DIRSTB 0x00000004
 
+enum class PIInterruptSource
+{
+    PI,
+    RSW,
+    DI,
+    SI,
+    EXI,
+    AI,
+    DSP,
+    MEM,
+    VI,
+    PE_TOKEN,
+    PE_FINISH,
+    CP,
+    DEBUG,
+    HSP,
+
+    Max,
+};
+
 // ---------------------------------------------------------------------------
 // hardware API
 
@@ -78,6 +98,7 @@ struct PIControl
     bool        rswhack;        // reset "switch" hack
     bool        log;            // log interrupts
     uint32_t    consoleVer;     // console version
+    int64_t     intCounters[(size_t)PIInterruptSource::Max];      // interrupt counters
 };
 
 extern  PIControl pi;
@@ -85,3 +106,4 @@ extern  PIControl pi;
 void PIAssertInt(uint32_t mask);  // set interrupt(s)
 void PIClearInt(uint32_t mask);   // clear interrupt(s)
 void PIOpen(HWConfig * config);
+void PIClose();

--- a/SRC/Hardware/VI.h
+++ b/SRC/Hardware/VI.h
@@ -106,7 +106,7 @@ struct VIControl
     RGB*        gfxbuf;     // DIB
 
     bool        log;        // do debugger log output
-    size_t      frames;     // frames rendered by VI/GX
+    size_t      frames;     // frames rendered by VI
 
     int64_t     one_second;     // one CPU second in timer ticks
 

--- a/SRC/HighLevel/HleCommands.cpp
+++ b/SRC/HighLevel/HleCommands.cpp
@@ -141,12 +141,25 @@ namespace HLE
         return output;
     }
 
+    static Json::Value* OSDateTimeInternal(std::vector<std::string>& args)
+    {
+        wchar_t timeStr[0x100] = { 0, };
+
+        OSTimeFormat(timeStr, Gekko::Gekko->GetTicks(), false);
+
+        Json::Value* output = new Json::Value();
+        output->type = Json::ValueType::Array;
+
+        output->AddString(nullptr, timeStr);
+
+        return output;
+    }
+
     static Json::Value* OSTimeInternal(std::vector<std::string>& args)
     {
         wchar_t timeStr[0x100] = { 0, };
 
-        // TODO:
-        //OSTimeFormat(timeStr, strtoull(args[1].c_str(), nullptr, 0), true);
+        OSTimeFormat(timeStr, Gekko::Gekko->GetTicks(), true);
 
         Json::Value* output = new Json::Value();
         output->type = Json::ValueType::Array;
@@ -187,6 +200,7 @@ namespace HLE
         JDI::Hub.AddCmd("AddMap", AddMap);
         JDI::Hub.AddCmd("AddressByName", AddressByName);
         JDI::Hub.AddCmd("NameByAddress", NameByAddress);
+        JDI::Hub.AddCmd("OSDateTime", OSDateTimeInternal);
         JDI::Hub.AddCmd("OSTime", OSTimeInternal);
         JDI::Hub.AddCmd("GetNearestName", GetNearestNameInternal);
 	}

--- a/SRC/HighLevel/Scripts/CMakeLists.txt
+++ b/SRC/HighLevel/Scripts/CMakeLists.txt
@@ -10,4 +10,5 @@ add_library (HighLevel SHARED
 	../OS.cpp
 	../Stdc.cpp
 	../Symbols.cpp
+	../TimeFormat.cpp
 )

--- a/SRC/HighLevel/TimeFormat.cpp
+++ b/SRC/HighLevel/TimeFormat.cpp
@@ -15,6 +15,7 @@ namespace HLE
         //      2: assume X - 1/10000000 sec, Y - 1/40500000 sec,
         //         FILETIME = (GCTIME * Y) / X
 
+#ifndef _LINUX
         // coversion GCTIME -> FILETIME
         #define MAGIK 0x0713AD7857941000
         double x = 1.0 / 10000000.0, y = 1.0 / 40500000.0;
@@ -26,11 +27,12 @@ namespace HLE
         FileTimeToSystemTime(&fileTime, &sysTime);
 
         // format string
-        static const wchar_t* mnstr[12] =
-        { L"Jan", L"Feb", L"Mar", L"Apr",
-          L"May", L"Jun", L"Jul", L"Aug",
-          L"Sep", L"Oct", L"Nov", L"Dec"
+        static const wchar_t* mnstr[12] = {
+            L"Jan", L"Feb", L"Mar", L"Apr",
+            L"May", L"Jun", L"Jul", L"Aug",
+            L"Sep", L"Oct", L"Nov", L"Dec"
         };
+
         if (noDate)
         {
             swprintf_s(gcTime, 255, L"%02i:%02i:%02i:%03i",
@@ -38,10 +40,11 @@ namespace HLE
         }
         else
         {
-            wprintf_s(gcTime, 255, L"%i %s %i %02i:%02i:%02i:%03i",
+            swprintf_s(gcTime, 255, L"%i %s %i %02i:%02i:%02i:%03i",
                 sysTime.wDay, mnstr[sysTime.wMonth - 1], sysTime.wYear,
                 sysTime.wHour, sysTime.wMinute, sysTime.wSecond, sysTime.wMilliseconds);
         }
+#endif
     }
 
 }

--- a/SRC/UI/Legacy/DolwinLegacy/Scripts/VS2015/DolwinLegacy.vcxproj
+++ b/SRC/UI/Legacy/DolwinLegacy/Scripts/VS2015/DolwinLegacy.vcxproj
@@ -191,6 +191,7 @@
     <ClCompile Include="..\..\UserMain.cpp" />
     <ClCompile Include="..\..\UserMemcards.cpp" />
     <ClCompile Include="..\..\UserPadConfigure.cpp" />
+    <ClCompile Include="..\..\UserPerfMetrics.cpp" />
     <ClCompile Include="..\..\UserSelector.cpp" />
     <ClCompile Include="..\..\UserSettings.cpp" />
     <ClCompile Include="..\..\UserWindow.cpp" />
@@ -209,6 +210,7 @@
     <ClInclude Include="..\..\UserMain.h" />
     <ClInclude Include="..\..\UserMemcards.h" />
     <ClInclude Include="..\..\UserPadConfigure.h" />
+    <ClInclude Include="..\..\UserPerfMetrics.h" />
     <ClInclude Include="..\..\UserSelector.h" />
     <ClInclude Include="..\..\UserSettings.h" />
     <ClInclude Include="..\..\UserWindow.h" />

--- a/SRC/UI/Legacy/DolwinLegacy/Scripts/VS2015/DolwinLegacy.vcxproj.filters
+++ b/SRC/UI/Legacy/DolwinLegacy/Scripts/VS2015/DolwinLegacy.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="..\..\UserCommands.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\UserPerfMetrics.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\DVDBanner.h">
@@ -102,6 +105,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\UserCommands.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UserPerfMetrics.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/SRC/UI/Legacy/DolwinLegacy/Scripts/VS2019/DolwinLegacy.vcxproj
+++ b/SRC/UI/Legacy/DolwinLegacy/Scripts/VS2019/DolwinLegacy.vcxproj
@@ -191,6 +191,7 @@
     <ClCompile Include="..\..\UserMain.cpp" />
     <ClCompile Include="..\..\UserMemcards.cpp" />
     <ClCompile Include="..\..\UserPadConfigure.cpp" />
+    <ClCompile Include="..\..\UserPerfMetrics.cpp" />
     <ClCompile Include="..\..\UserSelector.cpp" />
     <ClCompile Include="..\..\UserSettings.cpp" />
     <ClCompile Include="..\..\UserWindow.cpp" />
@@ -209,6 +210,7 @@
     <ClInclude Include="..\..\UserMain.h" />
     <ClInclude Include="..\..\UserMemcards.h" />
     <ClInclude Include="..\..\UserPadConfigure.h" />
+    <ClInclude Include="..\..\UserPerfMetrics.h" />
     <ClInclude Include="..\..\UserSelector.h" />
     <ClInclude Include="..\..\UserSettings.h" />
     <ClInclude Include="..\..\UserWindow.h" />

--- a/SRC/UI/Legacy/DolwinLegacy/Scripts/VS2019/DolwinLegacy.vcxproj.filters
+++ b/SRC/UI/Legacy/DolwinLegacy/Scripts/VS2019/DolwinLegacy.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClCompile Include="..\..\UserCommands.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\UserPerfMetrics.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\DVDBanner.h">
@@ -102,6 +105,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\UserCommands.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UserPerfMetrics.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/SRC/UI/Legacy/DolwinLegacy/UserJdiClient.cpp
+++ b/SRC/UI/Legacy/DolwinLegacy/UserJdiClient.cpp
@@ -4,7 +4,7 @@
 
 namespace UI
 {
-	JdiClient * Jdi;
+	JdiClient* Jdi;
 
 	JdiClient::JdiClient()
 	{
@@ -15,11 +15,11 @@ namespace UI
 			UI::DolwinError(L"Error", L"Failed to load DolwinEmu.dll. This component contains the emulator core and is required for correct operation.");
 		}
 
-		CallJdi = (CALL_JDI) GetProcAddress(dll, "CallJdi");
-		CallJdiNoReturn = (CALL_JDI_NO_RETURN) GetProcAddress(dll, "CallJdiNoReturn");
-		CallJdiReturnInt = (CALL_JDI_RETURN_INT) GetProcAddress(dll, "CallJdiReturnInt");
-		CallJdiReturnString = (CALL_JDI_RETURN_STRING) GetProcAddress(dll, "CallJdiReturnString");
-		CallJdiReturnBool = (CALL_JDI_RETURN_BOOL) GetProcAddress(dll, "CallJdiReturnBool");
+		CallJdi = (CALL_JDI)GetProcAddress(dll, "CallJdi");
+		CallJdiNoReturn = (CALL_JDI_NO_RETURN)GetProcAddress(dll, "CallJdiNoReturn");
+		CallJdiReturnInt = (CALL_JDI_RETURN_INT)GetProcAddress(dll, "CallJdiReturnInt");
+		CallJdiReturnString = (CALL_JDI_RETURN_STRING)GetProcAddress(dll, "CallJdiReturnString");
+		CallJdiReturnBool = (CALL_JDI_RETURN_BOOL)GetProcAddress(dll, "CallJdiReturnBool");
 
 		JdiAddNode = (JDI_ADD_NODE)GetProcAddress(dll, "JdiAddNode");
 		JdiRemoveNode = (JDI_REMOVE_NODE)GetProcAddress(dll, "JdiRemoveNode");
@@ -230,6 +230,30 @@ namespace UI
 	void JdiClient::Reset()
 	{
 		ExecuteCommand("reset");
+	}
+
+	// Performance Counters, SystemTime
+
+	int64_t JdiClient::GetPerformanceCounter(int counter)
+	{
+		Json::Value* value = CallJdi(("GetPerformanceCounter " + std::to_string(counter)).c_str());
+		int64_t res = value->value.AsInt;
+		delete value;
+		return res;
+	}
+
+	void JdiClient::ResetPerformanceCounter(int counter)
+	{
+		ExecuteCommand(("ResetPerformanceCounter " + std::to_string(counter)).c_str());
+	}
+
+	std::string JdiClient::GetSystemTime()
+	{
+		uint64_t tbr = 0;
+		Json::Value* value = CallJdi("OSDateTime");
+		std::string res = Util::WstringToString(value->children.front()->value.AsString);
+		delete value;
+		return res;
 	}
 
 }

--- a/SRC/UI/Legacy/DolwinLegacy/UserJdiClient.h
+++ b/SRC/UI/Legacy/DolwinLegacy/UserJdiClient.h
@@ -85,6 +85,12 @@ namespace UI
 		void Stop();
 		void Reset();
 
+		// Performance Counters, SystemTime
+
+		int64_t GetPerformanceCounter(int counter);
+		void ResetPerformanceCounter(int counter);
+		std::string GetSystemTime();
+
 	};
 
 	extern JdiClient * Jdi;

--- a/SRC/UI/Legacy/DolwinLegacy/UserPerfMetrics.cpp
+++ b/SRC/UI/Legacy/DolwinLegacy/UserPerfMetrics.cpp
@@ -1,0 +1,109 @@
+/*
+
+# Performance Counters
+
+Interesting to track :
+- The number of emulated Gekko instructions (million per second, mips)
+- Number of DSP instructions emulated (million per second, mips)
+- Number of VI interrupts (frames per second)
+- Number of draw operations (PE DrawDone / second)
+- Show formatted value of TBR register (OSSystemTime)
+
+*/
+
+#include "pch.h"
+
+namespace UI
+{
+
+	// Global instance of the utility, which is controlled in the UserWindow.cpp module
+	PerfMetrics* g_perfMetrics = nullptr;
+
+
+	void PerfMetrics::PerfThreadProc(void* param)
+	{
+		PerfMetrics* perf = (PerfMetrics*)param;
+
+		// Get and reset counters
+
+		int64_t gekkoMips = perf->GetGekkoInstructionsCounter();
+		perf->ResetGekkoInstructionsCounter();
+
+		int64_t dspMips = perf->GetDspInstructionsCounter();
+		perf->ResetDspInstructionsCounter();
+
+		char str[0x100];
+		sprintf_s(str, sizeof(str), "gekko: %.02f mips, dsp: %.02f mips", (float)gekkoMips / 1000000.f, (float)dspMips / 1000000.f);
+
+		int32_t vis = perf->GetVICounter();
+		perf->ResetVICounter();
+
+		int32_t pes = perf->GetPECounter();
+		perf->ResetPECounter();
+
+		// Display information in the status bar
+
+		SetStatusText(STATUS_ENUM::Progress, Util::StringToWstring(str));
+		SetStatusText(STATUS_ENUM::VIs, std::to_wstring(vis) + L" VI/s");
+		SetStatusText(STATUS_ENUM::PEs, std::to_wstring(pes) + L" PE/s");
+		SetStatusText(STATUS_ENUM::SystemTime, Util::StringToWstring(perf->GetSystemTime()));
+
+		Thread::Sleep(perf->metricsInterval);
+	}
+
+	PerfMetrics::PerfMetrics()
+	{
+		perfThread = new Thread(PerfThreadProc, false, this, "PerfThread");
+	}
+
+	PerfMetrics::~PerfMetrics()
+	{
+		delete perfThread;
+	}
+
+	int64_t PerfMetrics::GetGekkoInstructionsCounter()
+	{
+		return Jdi->GetPerformanceCounter(0);
+	}
+
+	void PerfMetrics::ResetGekkoInstructionsCounter()
+	{
+		Jdi->ResetPerformanceCounter(0);
+	}
+
+	int64_t PerfMetrics::GetDspInstructionsCounter()
+	{
+		return Jdi->GetPerformanceCounter(1);
+	}
+
+	void PerfMetrics::ResetDspInstructionsCounter()
+	{
+		Jdi->ResetPerformanceCounter(1);
+	}
+
+	int32_t PerfMetrics::GetVICounter()
+	{
+		return Jdi->GetPerformanceCounter(2);
+	}
+
+	void PerfMetrics::ResetVICounter()
+	{
+		Jdi->ResetPerformanceCounter(2);
+	}
+
+	int32_t PerfMetrics::GetPECounter()
+	{
+		return Jdi->GetPerformanceCounter(3);
+	}
+
+	void PerfMetrics::ResetPECounter()
+	{
+		Jdi->ResetPerformanceCounter(3);
+	}
+
+	std::string PerfMetrics::GetSystemTime()
+	{
+		return Jdi->GetSystemTime();
+	}
+
+}

--- a/SRC/UI/Legacy/DolwinLegacy/UserPerfMetrics.h
+++ b/SRC/UI/Legacy/DolwinLegacy/UserPerfMetrics.h
@@ -1,0 +1,41 @@
+
+#pragma once
+
+// The counters are polled once a second after starting the emulation.
+// Polling is performed in a separate thread that sleeps after polling so as not to load the CPU. The information is displayed in the status bar.
+
+namespace UI
+{
+
+	class PerfMetrics
+	{
+		size_t metricsInterval = 1000;
+
+		Thread* perfThread;
+		static void PerfThreadProc(void* param);
+
+		// The counter values are retrieved and cleared using JDI.
+
+		int64_t GetGekkoInstructionsCounter();
+		void ResetGekkoInstructionsCounter();
+
+		int64_t GetDspInstructionsCounter();
+		void ResetDspInstructionsCounter();
+
+		int32_t GetVICounter();
+		void ResetVICounter();
+
+		int32_t GetPECounter();
+		void ResetPECounter();
+
+		std::string GetSystemTime();
+
+	public:
+		PerfMetrics();
+		~PerfMetrics();
+	};
+
+
+	extern PerfMetrics* g_perfMetrics;
+
+}

--- a/SRC/UI/Legacy/DolwinLegacy/UserWindow.cpp
+++ b/SRC/UI/Legacy/DolwinLegacy/UserWindow.cpp
@@ -17,10 +17,10 @@ Debug::GekkoDebug* gekkoDebug;
 /* Set default values of statusbar parts */
 static void ResetStatusBar()
 {
-    SetStatusText(STATUS_ENUM::Progress, L"Idle");
-    SetStatusText(STATUS_ENUM::Fps,      L"");
-    SetStatusText(STATUS_ENUM::Timing,   L"");
-    SetStatusText(STATUS_ENUM::Time,     L"");
+    SetStatusText(STATUS_ENUM::Progress,    L"Idle");
+    SetStatusText(STATUS_ENUM::VIs,         L"");
+    SetStatusText(STATUS_ENUM::PEs,         L"");
+    SetStatusText(STATUS_ENUM::SystemTime,  L"");
 }
 
 /* Create status bar window */
@@ -72,7 +72,7 @@ std::wstring GetStatusText(STATUS_ENUM sbPart)
 {
     static auto sbText = std::wstring(256, 0);
 
-    if (wnd.hStatusWindow == NULL) return NULL;
+    if (wnd.hStatusWindow == NULL) return L"";
 
     SendMessage(wnd.hStatusWindow, SB_GETTEXT, (WPARAM)(sbPart), (LPARAM)sbText.data());
     return sbText;
@@ -560,11 +560,15 @@ void OnMainWindowOpened(const wchar_t* currentFileName)
     }
     
     SetWindowText(wnd.hMainWindow, newTitle.c_str());
+
+    UI::g_perfMetrics = new UI::PerfMetrics();
 }
 
 // emulation stop in progress
 void OnMainWindowClosed()
 {
+    delete UI::g_perfMetrics;
+
     // restore current working directory
     SetCurrentDirectory(wnd.cwd.c_str());
 

--- a/SRC/UI/Legacy/DolwinLegacy/UserWindow.h
+++ b/SRC/UI/Legacy/DolwinLegacy/UserWindow.h
@@ -7,10 +7,10 @@ constexpr int WIN_STYLE = WS_OVERLAPPED | WS_SYSMENU | WS_CLIPCHILDREN | WS_CLIP
 /* Status bar parts enumerator */
 enum class STATUS_ENUM
 {
-    Progress = 1,        /* current emu state   */
-    Fps,                 /* fps counter         */
-    Timing,              /* * Obsolete *        */
-    Time,                /* time counter        */
+    Progress = 1,       // Current emu state / Gekko/DSP performance counters
+    VIs,                // VI / second
+    PEs,                // PE DrawDone / second
+    SystemTime,         // OS System Time
 };
 
 void SetStatusText(STATUS_ENUM sbPart, const std::wstring & text, bool post=false);

--- a/SRC/UI/Legacy/DolwinLegacy/pch.h
+++ b/SRC/UI/Legacy/DolwinLegacy/pch.h
@@ -37,6 +37,7 @@
 #include "DVDBanner.h"			// banner utilities for selector
 #include "SjisTable.h"
 #include "UserCommands.h"
+#include "UserPerfMetrics.h"
 
 #include "../../../../ThirdParty/fmt/fmt/format.h"
 #include "../../../../ThirdParty/fmt/fmt/printf.h"


### PR DESCRIPTION
For the upcoming release, you need some kind of tool to measure the overall performance of the emulator.

In older versions, statistics were shown in the status bar; during refactoring, they were broken.

Need to return.

Interesting to track:

- The number of emulated Gekko instructions (million per second, mips)
- Number of DSP instructions emulated (million per second, mips)
- Number of VI interrupts (frames per second)
- Number of draw operations (PE DrawDone / second)
- Show formatted value of TBR register (OSSystemTime)