### PR TITLE
Fixed reentrancy bug

### DIFF
--- a/SRC/Backends/DolwinVideo/Fifo.h
+++ b/SRC/Backends/DolwinVideo/Fifo.h
@@ -57,3 +57,5 @@ extern  uint32_t     lastFifoSize;
 // for gpregs module
 // called after any changes of VCD / VAT
 void FifoReconfigure();
+
+extern GX_FromFuture::FifoProcessor GxFifo;

--- a/SRC/Backends/DolwinVideo/FifoProcessor.cpp
+++ b/SRC/Backends/DolwinVideo/FifoProcessor.cpp
@@ -294,4 +294,9 @@ namespace GX_FromFuture
 	{
 		return ((uint16_t)Peek8(offset) << 8) | Peek8(offset + 1);
 	}
+
+	void FifoProcessor::Reset()
+	{
+		readPtr = writePtr = 0;
+	}
 }

--- a/SRC/Backends/DolwinVideo/FifoProcessor.h
+++ b/SRC/Backends/DolwinVideo/FifoProcessor.h
@@ -30,5 +30,7 @@ namespace GX_FromFuture
 
 		uint8_t Peek8(size_t offset);
 		uint8_t Peek16(size_t offset);
+
+		void Reset();
 	};
 }

--- a/SRC/Backends/DolwinVideo/GX.cpp
+++ b/SRC/Backends/DolwinVideo/GX.cpp
@@ -100,9 +100,11 @@ long GXOpen(HWConfig* config, uint8_t * ramPtr)
     // flush texture cache
     TexInit();
 
-    gxOpened = true;
-
     JDI::Hub.AddNode(DOLWIN_VIDEO_JDI_JSON, DolwinVideoReflector);
+
+    GxFifo.Reset();
+
+    gxOpened = true;
 
     return true;
 }

--- a/SRC/Debugger/Perf.h
+++ b/SRC/Debugger/Perf.h
@@ -1,4 +1,6 @@
-// Performance Counters
+// Performance Counters.
+
+// Statistics are sent to the UI through the GetPerformanceCounter / ResetPerformanceCounter Jdi commands.
 
 #pragma once
 
@@ -7,10 +9,10 @@ namespace Debug
 
 	enum class PerfCounter
 	{
-		GekkoInstructions = 0,
-		DspInstructions,
-		VIs,
-		PEs,
+		GekkoInstructions = 0,		// Number of Gekko instructions executed
+		DspInstructions,		// Number of DSP instructions executed
+		VIs,				// Number of VI VBlank interrupts (based on PI interrupt counters)
+		PEs,				// Number of PE DRAW_DONE operations (based on PI interrupt counters)
 
 		Max,
 	};
@@ -26,5 +28,7 @@ namespace Debug
 		void ResetAllCounters();
 	};
 
+	// A global instance, created by the emulator in the EMUCtor method and is available throughout the life of the emulator
+	// (another thing is that statistics are updated only when the emulator is running).
 	extern PerfCounters* g_PerfCounters;
 }

--- a/SRC/Debugger/SamplingProfiler.cpp
+++ b/SRC/Debugger/SamplingProfiler.cpp
@@ -20,7 +20,7 @@ namespace Debug
 	{
 		filename = jsonFileName;
 
-		pollingInterval = periodMs * Gekko::Gekko->OneMillisecond();
+		pollingInterval = periodMs * (Gekko::Gekko->OneSecond() / 1000);
 		savedGekkoTbr = Gekko::Gekko->GetTicks();
 
 		json = new Json();

--- a/SRC/Hardware/CP_PE.cpp
+++ b/SRC/Hardware/CP_PE.cpp
@@ -13,7 +13,7 @@ static void CPDrawDoneCallback()
     pe_done_num++;
     if (pe_done_num == 1)
     {
-        vi.xfb = 0;     // disable VI output
+        vi.xfb = false;     // disable VI output
     }
 
     Flipper::Gx->CPDrawDoneCallback();
@@ -21,7 +21,7 @@ static void CPDrawDoneCallback()
 
 static void CPDrawTokenCallback(uint16_t tokenValue)
 {
-    vi.xfb = 0;     // disable VI output
+    vi.xfb = false;     // disable VI output
 
     Flipper::Gx->CPDrawTokenCallback(tokenValue);
 }
@@ -55,6 +55,8 @@ static void PERegWrite(uint32_t addr, uint32_t data)
 void CP_PEOpen()
 {
     Report(Channel::CP, "Command processor and Pixel Engine (for GX)\n");
+
+    pe_done_num = 0;
 
     // Command Processor
     MISetTrap(16, PI_REG16_TO_SPACE(PI_REGSPACE_CP, GX::CPMappedRegister::CP_STATUS_ID), CPRegRead, CPRegWrite);

--- a/SRC/HighLevel/TimeFormat.cpp
+++ b/SRC/HighLevel/TimeFormat.cpp
@@ -17,7 +17,7 @@ namespace HLE
         static const int dayMonLeap[] = { 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
         #define IsLeapYear(y)  ((y % 1000) == 0 || (y % 4) == 0)
 
-        int64_t ticksPerMs = Gekko::Gekko->OneMillisecond();
+        int64_t ticksPerMs = Gekko::Gekko->OneSecond() / 1000;
         int64_t ms = tbr / ticksPerMs;
         int64_t msPerDay = 24 * 60 * 60 * 1000;
         int64_t days = ms / msPerDay;

--- a/SRC/UI/Legacy/DolwinLegacy/Scripts/VS2015/DolwinLegacy.vcxproj
+++ b/SRC/UI/Legacy/DolwinLegacy/Scripts/VS2015/DolwinLegacy.vcxproj
@@ -74,21 +74,25 @@
     <LinkIncremental>true</LinkIncremental>
     <IntDir>$(SolutionDir)Output\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <OutDir>$(SolutionDir)</OutDir>
+    <TargetName>$(ProjectName.Replace('Legacy',''))</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <IntDir>$(SolutionDir)Output\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <OutDir>$(SolutionDir)</OutDir>
+    <TargetName>$(ProjectName.Replace('Legacy',''))</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <IntDir>$(SolutionDir)Output\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <OutDir>$(SolutionDir)</OutDir>
+    <TargetName>$(ProjectName.Replace('Legacy',''))</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <IntDir>$(SolutionDir)Output\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <OutDir>$(SolutionDir)</OutDir>
+    <TargetName>$(ProjectName.Replace('Legacy',''))</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/SRC/UI/Legacy/DolwinLegacy/Scripts/VS2019/DolwinLegacy.vcxproj
+++ b/SRC/UI/Legacy/DolwinLegacy/Scripts/VS2019/DolwinLegacy.vcxproj
@@ -74,21 +74,25 @@
     <LinkIncremental>true</LinkIncremental>
     <IntDir>$(SolutionDir)Output\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <OutDir>$(SolutionDir)</OutDir>
+    <TargetName>$(ProjectName.Replace('Legacy',''))</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
     <IntDir>$(SolutionDir)Output\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <OutDir>$(SolutionDir)</OutDir>
+    <TargetName>$(ProjectName.Replace('Legacy',''))</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <IntDir>$(SolutionDir)Output\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <OutDir>$(SolutionDir)</OutDir>
+    <TargetName>$(ProjectName.Replace('Legacy',''))</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <IntDir>$(SolutionDir)Output\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <OutDir>$(SolutionDir)</OutDir>
+    <TargetName>$(ProjectName.Replace('Legacy',''))</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
Found why the emulator got up with bug after Open -> Close -> Open. The GekkoCore thread stopped in the middle of executing an instruction, but you need to put it into a suspended state carefully, waiting for the instructions to be emulated.

Also, the FIFO was not reset in DolwinVideo (this component is slowly being rewritten to a more adequate implementation)